### PR TITLE
Update readme.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,8 @@ This is a WIP for a wallet/node powered by utreexo. This codebase can download a
 This code also has an out-of-the-box Electrum Server that you can use with any wallet that supports it.
 
 ### Building
-You'll need Rust and Cargo, refer to [this](https://www.rust-lang.org/) for more details.
+You'll need Rust and Cargo, refer to [this](https://www.rust-lang.org/) for more details. Minimum support version is rustc 1.64 and newer.
+
 Once you have Cargo, clone the repository with:
 ```bash
 $ git clone https://github.com/Davidson-Souza/utreexo-electrum-server


### PR DESCRIPTION
Dependency clap v4.1.4 requires rustc 1.64 or newer.

For future reference, seems like the project requires Rust 2021 Edition so likely that 1.56.0 is required even if clap was removed or the requirements were lowered, the minimum would be around 1.56.0